### PR TITLE
header should have only string object

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -59,7 +59,7 @@ var parseWorkbook = function(workbook, sline, hline){
         row.push(cellValue);
       }else{
         //add the header row
-        header.push(new String(cellValue));
+        header.push(cellValue.toString());
       }
     }
     if(i !== hline){

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,7 @@ var parseWorkbook = function(workbook, sline, hline){
   };
   var row;
   var result = [];
-  for(var i = 0; i < rlength; i++){
+  for(var i = hline; i < rlength; i++){
     row = [];
     for(var j = 0; j < clength; j++){
       var cell = getCurrentCell(cols[0], row, i, j);
@@ -59,7 +59,7 @@ var parseWorkbook = function(workbook, sline, hline){
         row.push(cellValue);
       }else{
         //add the header row
-        header.push(cellValue);
+        header.push(new String(cellValue));
       }
     }
     if(i !== hline){

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -13,7 +13,7 @@ var getCurrentCell = function(col, row, i, j){
 /**
 * workbook the workbook that contains the sheet to map
 * sline the position of the sheet of the workbook to map
-* hline the position (start at 0) of the header line.
+* hline the position of the header line.
 */
 var parseWorkbook = function(workbook, sline, hline){
   //get the sheetname at position 'sline' (start at 0)


### PR DESCRIPTION
header should have only string object, if header data is not string object, header[i].trim() fail. and row start index should start at hline.
