### PR TITLE
fix: relax node and npm requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
   },
   "license": "MIT",
   "main": "index.js",
-  "engines": {
-    "node": "4.5.0",
-    "npm": "3.12.8"
-  },
   "keywords":[
     "parser",
     "xls",


### PR DESCRIPTION
node@4 has been deprecated long time ago and the package works even in node@10 LTS. I update/relaxed/removed the requirement for the node and npm to be used in our project.

pls consider merging and publishing